### PR TITLE
Don't use npm audit fix (just update)

### DIFF
--- a/autupdate.sh
+++ b/autupdate.sh
@@ -53,7 +53,10 @@ while IFS='' read -r repo || [[ -n "$repo" ]]; do
   git checkout -B update-dependencies
   git reset --hard  origin/master
 
-  npm audit fix > $CLONE_LOCATION/.autoupdate/npm_report/$repo.txt &&
+  # We should ultimately run both npm update and npm audit fix to
+  # update dependencies as well as address any vulnerabilities.
+  # Currently our Jenkins server does not have a version of npm that has the audit functionality.
+  npm update > $CLONE_LOCATION/.autoupdate/npm_report/$repo.txt &&
   git add package-lock.json package.json &&
   git commit -m "Update dependencies" &&
   git push origin update-dependencies &&


### PR DESCRIPTION
The version of npm running on our jenkins server doesn't support `audit`

Feel free to approve, and I can merge and kill the build before it triggers updates.