### PR TITLE
Remove workflow-archiver-job

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -27,5 +27,4 @@ sdr-services-app
 was-registrar
 was_robot_suite
 was-thumbnail-service
-workflow-archiver-job
 workflow-server-rails


### PR DESCRIPTION
The workflow-archiver-job is no longer used in DLSS