### PR TITLE
Move revs-indexer-service to access team

### DIFF
--- a/access/ruby
+++ b/access/ruby
@@ -12,6 +12,8 @@ mods_display_app
 purl
 purl-fetcher
 relevancy_dashboard
+revs
+revs-indexer-service
 SearchWorks
 searchworks_traject_indexer
 stacks

--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -13,8 +13,6 @@ modsulator-app-rails
 preservation_catalog
 preservation_robots
 pre-assembly
-revs
-revs-indexer-service
 rialto-webapp
 robot-master
 sul_pub


### PR DESCRIPTION
The repository is tagged as an access team responsibility and listed in the Access team portfolio: https://consul.stanford.edu/display/DSG/DLSS+Software+Portfolios+and+teams