### PR TITLE
add was-registrar-app to infrastructure

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -21,4 +21,5 @@ sdr-services-app
 was-registrar
 was_robot_suite
 was-thumbnail-service
+was-registrar-app
 workflow-server-rails


### PR DESCRIPTION
NOTE to whomever merges:  "when you merge PRs to access-update-scripts, please kill the build on (https:// )   sul-ci-prod.stanford.edu to avoid running updates again and again and again"