### PR TITLE
add lyberservices-scripts to infrastructure projects

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -7,6 +7,7 @@ dor-fetcher-service
 gis-robot-suite
 hydra_etd
 hydrus
+lyberservices-scripts
 modsulator-app-rails
 preservation_catalog
 preservation_robots


### PR DESCRIPTION
lyberservices-scripts is a replacement for pre-assembly v3-legacy branch.