### PR TITLE
Remove dlme-harvest

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -1,7 +1,6 @@
 argo
 common-accessioning
 dlme
-dlme-harvest
 dlme-transform
 dor-services-app
 dor_indexing_app


### PR DESCRIPTION
This application is not maintained by the infrastructure team directly and updates may introduce breaking changes that affect the DLME managers workflow.