### PR TITLE
Added integration tests repo

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -9,6 +9,7 @@ sul-dlss/gis-robot-suite
 sul-dlss/google-books
 sul-dlss/hydra_etd
 sul-dlss/hydrus
+sul-dlss/infrastructure-integration-test
 sul-dlss/lyberservices-scripts
 sul-dlss/modsulator-app-rails
 sul-dlss/pre-assembly


### PR DESCRIPTION
Adds Infrastructure Integration tests for weekly dependencies updates. Replaces manual update (for example PR https://github.com/sul-dlss/infrastructure-integration-test/pull/25)