### PR TITLE
Move DLME webapp to the access team updates

### DIFF
--- a/access/ruby
+++ b/access/ruby
@@ -3,6 +3,7 @@ sul-dlss/arclight-demo
 sul-dlss/bassi_veratti
 sul-dlss/content_search
 sul-dlss/course_reserves
+sul-dlss/dlme
 sul-dlss/earthworks
 sul-dlss/exhibits
 sul-dlss/library_hours_rails

--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -1,6 +1,5 @@
 sul-dlss/argo
 sul-dlss/common-accessioning
-sul-dlss/dlme
 sul-dlss/dlme-transform
 sul-dlss/dor-services-app
 sul-dlss/dor_indexing_app


### PR DESCRIPTION
As agreed, when this access work cycle started, DLME is to be moved to the access list.