### PR TITLE
Remove rialto from dep updates

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -13,8 +13,6 @@ sul-dlss/modsulator-app-rails
 sul-dlss/pre-assembly
 sul-dlss/preservation_catalog
 sul-dlss/preservation_robots
-sul-dlss/rialto-etl
-sul-dlss/rialto-webapp
 sul-dlss/robot-console
 sul-dlss/sdr-api
 sul-dlss/sul_pub


### PR DESCRIPTION
We will no longer need to maintain updates on rialto soon. When we've turned off the AWS infrastructure, remove rialto from automated update scripts.