### PR TITLE
Remove lyberservices-scripts from dependency updates

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -8,7 +8,6 @@ sul-dlss/google-books
 sul-dlss/hydra_etd
 sul-dlss/hydrus
 sul-dlss/infrastructure-integration-test
-sul-dlss/lyberservices-scripts
 sul-dlss/modsulator-app-rails
 sul-dlss/pre-assembly
 sul-dlss/preservation_catalog


### PR DESCRIPTION
It's deprecated.