### PR TITLE
add wasapi-downloader to infra ruby project list

### DIFF
--- a/infrastructure/projects
+++ b/infrastructure/projects
@@ -20,6 +20,7 @@ sul-dlss/suri-rails
 sul-dlss/technical-metadata-service
 sul-dlss/was_robot_suite
 sul-dlss/was-registrar-app
+sul-dlss/wasapi-downloader
 sul-dlss/workflow-server-rails
 LD4P/sinopia_api
 LD4P/sinopia_editor


### PR DESCRIPTION
though it's primarily a java project, it does have `Gemfile` and `Gemfile.lock`, since capistrano is used for deployment.

fwiw, i don't think wasapi-downloader needs to be deployed for weekly dep updates, since the deployment mechanism itself is the only thing that'll be updated (since we don't yet automate dep updates for our handful of java projects).

may not be worth including in the list, and would not be bothered if this was closed accordingly -- didn't take long to make the change, and was quicker to do this only to have it closed, than to ask about it in slack.

https://github.com/sul-dlss/wasapi-downloader/blob/master/Gemfile