### PR TITLE
was-thumbnail-service has been decommissioned

### DIFF
--- a/infrastructure/ruby
+++ b/infrastructure/ruby
@@ -18,6 +18,5 @@ sul-dlss/sul_pub
 sul-dlss/suri-rails
 sul-dlss/technical-metadata-service
 sul-dlss/was_robot_suite
-sul-dlss/was-thumbnail-service
 sul-dlss/was-registrar-app
 sul-dlss/workflow-server-rails


### PR DESCRIPTION
see https://github.com/sul-dlss/was-thumbnail-service/issues/211

maybe this is premature since the VM has yet to be destroyed, and the project yet to be moved to the deprecated org?