### PR TITLE
Simplify repos file reading in merge-all

### DIFF
--- a/merge-all.rb
+++ b/merge-all.rb
@@ -9,7 +9,7 @@ def repos_file
 end
 
 def repos
-  [repos_file].map(&:to_a).flatten.map(&:strip).sort
+  repos_file.readlines(chomp: true)
 end
 
 # @return [Array<Hash>] the update PR


### PR DESCRIPTION
Not sure why we needed all that jazz before. We took a file, wrapped it in an array just to map it?, and then flattened it for reasons that escape me, and sorted it (for reasons).