### PR TITLE
merge-all script can also be used for cocina-level2-update branches

### DIFF
--- a/cocina_level2_prs.rb
+++ b/cocina_level2_prs.rb
@@ -62,7 +62,7 @@ end
 
 # must be called as part of the block for within_cloned_repo_dir(repo)
 def create_branch
-  ErrorEmittingExecutor.execute("git switch -C #{BRANCH_NAME}")
+  ErrorEmittingExecutor.execute("git checkout -B #{BRANCH_NAME}")
 
   # Ensure local branch matches any existing upstream branch; will reset to HEAD by default
   ErrorEmittingExecutor.execute('git reset --hard', exit_on_error: true)

--- a/cocina_level2_prs.rb
+++ b/cocina_level2_prs.rb
@@ -62,7 +62,7 @@ end
 
 # must be called as part of the block for within_cloned_repo_dir(repo)
 def create_branch
-  ErrorEmittingExecutor.execute("git checkout -B #{BRANCH_NAME}")
+  ErrorEmittingExecutor.execute("git switch -C #{BRANCH_NAME}")
 
   # Ensure local branch matches any existing upstream branch; will reset to HEAD by default
   ErrorEmittingExecutor.execute('git reset --hard', exit_on_error: true)


### PR DESCRIPTION
**CANCEL [BUILD on jenkins](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) IF MERGING!**

This change allows `merge-all` script to be used as it has been, but adds the ability for it to be used for cocina-level2-update branches.

Step 6b of sul-dlss/cocina-models/issues/176


NOTE:  I manually made some bogus branches and PRs and tested that the selection of correct PRs worked for both "update-depenedencies" and for "cocina-level2-updates"