### PR TITLE
Run infra and libsys builds w/o Slack integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,50 +7,15 @@ pipeline {
 
   environment {
     SIDEKIQ_PRO_SECRET = credentials("sidekiq_pro_secret")
-    ACCESS_TEAM_SLACK_API_TOKEN = credentials("access-team-slack-token")
     GH_ACCESS_TOKEN = credentials("sul-ci org token")
   }
 
   stages {
-    stage('Access') {
-
-      when {
-        allOf {
-          branch 'master';
-          not { triggeredBy 'SCMTrigger' }
-        }
-      }
-
-      steps {
-        checkout scm
-
-        sshagent (['sul-devops-team']){
-          sh '''#!/bin/bash -l
-          source /opt/rh/devtoolset-6/enable
-
-          export PATH=/ci/home/bin:$PATH
-          export HUB_CONFIG=/ci/home/config/hub
-          export REPOS_PATH=$WORKSPACE/access
-
-          # Load RVM
-          rvm use 3.1.2@access_dependency_updates --create
-          gem install bundler
-          bundle install
-
-          bundle config --global gems.contribsys.com $SIDEKIQ_PRO_SECRET
-          ./autupdate.sh
-
-          bundle exec ./git_hub_links.rb
-          '''
-        }
-      }
-    }
-
     stage('Infrastructure') {
 
       when {
         allOf {
-          branch 'master';
+          branch 'kick-infra-libsys-builds';
           not { triggeredBy 'SCMTrigger' }
         }
       }
@@ -73,8 +38,6 @@ pipeline {
 
           bundle config --global gems.contribsys.com $SIDEKIQ_PRO_SECRET
           ./autupdate.sh
-
-          bundle exec ./git_hub_links.rb
           '''
         }
       }
@@ -84,7 +47,7 @@ pipeline {
 
       when {
         allOf {
-          branch 'master';
+          branch 'kick-infra-libsys-builds';
           not { triggeredBy 'SCMTrigger' }
         }
       }
@@ -107,8 +70,6 @@ pipeline {
 
           bundle config --global gems.contribsys.com $SIDEKIQ_PRO_SECRET
           ./autupdate.sh
-
-          bundle exec ./git_hub_links.rb
           '''
         }
       }

--- a/autupdate.sh
+++ b/autupdate.sh
@@ -5,7 +5,7 @@
 
 SCRIPT_PATH=$(cd "$(dirname "$0")" ; pwd -P)
 REPOS_FILE="${REPOS_PATH:-$SCRIPT_PATH}/projects.yml"
-REPOS=$(./repos_wanting_update.rb $REPOS_FILE) 
+REPOS=$(./repos_wanting_update.rb $REPOS_FILE)
 CLONE_LOCATION=${WORKSPACE:-$TMPDIR}
 
 cd $CLONE_LOCATION
@@ -118,5 +118,5 @@ for item in $REPOS; do
 done
 
 cd $SCRIPT_PATH
-./slack_bot.rb "Dependency Updates Shipped!"
-./slack_bot.rb "`cat ${GEM_SUCCESS_REPORTS_ARRAY[*]} | grep "(was " | cut -f 2-5 -d " " | sort | uniq`"
+# ./slack_bot.rb "Dependency Updates Shipped!"
+# ./slack_bot.rb "`cat ${GEM_SUCCESS_REPORTS_ARRAY[*]} | grep "(was " | cut -f 2-5 -d " " | sort | uniq`"


### PR DESCRIPTION
This commit is a temporary one that works around the current broken Slack integration so that Infra and LibSys teams can proceed with weekly dependency updates. Not for PR, not to be merged.
