### PR TITLE
Remove dor-rights-auth from Infra portfolio

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -15,8 +15,6 @@ projects:
     cocina_level2: false
   - repo: sul-dlss/dor-event-client
     cocina_level2: false
-  - repo: sul-dlss/dor-rights-auth
-    cocina_level2: false
   - repo: sul-dlss/dor-services-app
     cocina_level2: false
   - repo: sul-dlss/dor-services-client


### PR DESCRIPTION
Only @sul-dlss/access-team services use it now.
