### PR TITLE
remove ksr app from infra team

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -29,8 +29,6 @@ projects:
   - repo: sul-dlss/happy-heron
   - repo: sul-dlss/hydra_etd
   - repo: sul-dlss/infrastructure-integration-test
-  - repo: sul-dlss/ksr-app
-    cocina_level2: false
   - repo: sul-dlss/lyber-core
     cocina_level2: false
   - repo: sul-dlss/moab-versioning


### PR DESCRIPTION
Remove the ksr-app from the infra team (no longer using the VM to run the website, using a google site instead). 

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
