### PR TITLE
merge-all: preview logic no longer needed

### DIFF
--- a/merge-all.rb
+++ b/merge-all.rb
@@ -36,10 +36,10 @@ def find_prs(client, entries)
     end
     puts "#{branch_name} pr found for #{repo}"
     statuses = client.combined_status(repo, pr.head.sha)
-    checks = client.check_runs_for_ref(repo, pr.head.sha, accept: Octokit::Preview::PREVIEW_TYPES[:checks])
+    checks = client.check_runs_for_ref(repo, pr.head.sha)
 
     begin
-      branch_protection = client.branch_protection(repo, pr.base.ref, accept: Octokit::Preview::PREVIEW_TYPES[:branch_protection])
+      branch_protection = client.branch_protection(repo, pr.base.ref)
       warn "No branch protection is set up for #{repo}" unless branch_protection
     rescue Octokit::NotFound => e
       warn "404 checking branch protection for #{repo}? #{e}"


### PR DESCRIPTION
⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)

From https://github.com/octokit/octokit.rb/releases/tag/v5.2.0, we haven't needed the preview logic and headers for 18 months or so.  octokit 6.1.0  won't work with these lines in.  So removing them.