### PR TITLE
Use Ruby 3.2.2 for infra builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
           export REPOS_PATH=$WORKSPACE/infrastructure
 
           # Load RVM
-          rvm use 3.0.3@infrastructure_dependency_updates --create
+          rvm use 3.2.2@infrastructure_dependency_updates --create
           gem install bundler
           bundle install --without production staging
 


### PR DESCRIPTION
Drafted so no one accidentally merges it w/o killing the build. Will merge and kill the build myself once approved.

This version of ruby is already installed on the CI server and soon all Infra projects will use 3.2.

-------

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
