### PR TITLE
add rialto-orgs app to dependency-updates

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -1,3 +1,4 @@
+# set merge: false if you want PRs to be ignored when running merge_all
 projects:
   - repo: sul-dlss/argo
   - repo: sul-dlss/assembly-image
@@ -50,6 +51,9 @@ projects:
     cocina_level2: false
   - repo: sul-dlss/preservation_robots
     cocina_level2: false
+  - repo: sul-dlss/rialto-orgs
+    cocina_level2: false
+    merge: false
   - repo: sul-dlss/robot-console
     cocina_level2: false
   - repo: sul-dlss/sdr-api

--- a/merge-all.rb
+++ b/merge-all.rb
@@ -17,11 +17,15 @@ def repos_file
   File.join ENV['REPOS_PATH'], 'projects.yml'
 end
 
+# return all projects from the project.yml file except those with merge: false set
+#  further filter by cocina_level2: true if ENV file set
 def repo_entries
-  return YAML.load_file(repos_file).fetch('projects') unless cocina_level2
+  projects = YAML.load_file(repos_file).fetch('projects')
+                 .select { |project| project.fetch('merge', true) }
 
-  YAML.load_file(repos_file).fetch('projects')
-    .select { |project| project.fetch('cocina_level2', true) }
+  return projects unless cocina_level2
+
+  projects.select { |project| project.fetch('cocina_level2', true) }
 end
 
 # @return [Array<Hash>] the update PR


### PR DESCRIPTION
Does two things:
1. adds a new infra rialto-orgs repo so we can get dependency-updates PR
2. adds a new param that can be added to the projects.yml file for infra projects so that repos can be skipped when running merge-all (and do this for new rialto-orgs repo added)

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
