### PR TITLE
infra project: remove dataloading-management

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -9,8 +9,6 @@ projects:
   - repo: sul-dlss/common-accessioning
   - repo: sul-dlss/datacite-ruby
     cocina_level2: false
-  - repo: sul-dlss/dataloading-management
-    cocina_level2: false
   - repo: sul-dlss/dlme-transform
     cocina_level2: false
   - repo: sul-dlss/dlss-capistrano-docker


### PR DESCRIPTION
⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)


we are no longer using this app.   If we end up using it, we can re-add it.