### PR TITLE
Skip CircleCI CLI update check when running CI

### DIFF
--- a/autupdate.sh
+++ b/autupdate.sh
@@ -45,7 +45,7 @@ for item in $REPOS; do
     .autoupdate/update
   else
     if test -f '.circleci/config.yml' && grep -q ruby-rails .circleci/config.yml; then
-      latest=$(circleci orb info sul-dlss/ruby-rails | grep 'Latest:' | cut -d@ -f2)
+      latest=$(circleci orb info sul-dlss/ruby-rails --skip-update-check | grep 'Latest:' | cut -d@ -f2)
 
       sed -i -e "s/sul-dlss\/ruby-rails@.*/sul-dlss\/ruby-rails@$latest/" .circleci/config.yml &&
         git add .circleci/config.yml &&


### PR DESCRIPTION
So we avoid busted dep update PRs like https://github.com/sul-dlss/google-books/pull/924#issuecomment-1568633762

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
