### PR TITLE
cocina_level2_prs: tolerate multiple possible success messages when detecting whether to create the PR

### DIFF
--- a/cocina_level2_prs.rb
+++ b/cocina_level2_prs.rb
@@ -26,9 +26,11 @@ BRANCH_NAME = 'cocina-level2-updates'
 GIT_MAIN_FETCH_REFS = '+refs/heads/main:refs/remotes/origin/main'
 GIT_BRANCH_FETCH_REFS = GIT_MAIN_FETCH_REFS.gsub('main', BRANCH_NAME).freeze
 COMMIT_DESCRIPTION = 'Update dependencies for cocina-models update'
-# keeping the old one in case someone has an older git version
-# EXPECTED_PUSH_MESSAGE = "Branch '#{BRANCH_NAME}' set up to track remote branch '#{BRANCH_NAME}' from 'origin'"
-EXPECTED_PUSH_MESSAGE = "branch '#{BRANCH_NAME}' set up to track 'origin/#{BRANCH_NAME}'."
+# the message depends on the locally installed version of git
+EXPECTED_PUSH_MESSAGES = [
+  "Branch '#{BRANCH_NAME}' set up to track remote branch '#{BRANCH_NAME}' from 'origin'",
+  "branch '#{BRANCH_NAME}' set up to track 'origin/#{BRANCH_NAME}'."
+]
 
 def repos_file
   File.join 'infrastructure', 'projects.yml'
@@ -58,7 +60,7 @@ def prepare_and_create_pr(repo)
     result = update_gems unless result_failure?('create_branch', result)
     result = local_git_commit unless result_failure?('update_gems', result)
     result = git_push_origin unless result_failure?('local_git_commit', result)
-    create_pr if result.include?(EXPECTED_PUSH_MESSAGE)
+    create_pr if EXPECTED_PUSH_MESSAGES.find { |msg| result.include?(msg) }
   end
 end
 


### PR DESCRIPTION
i tested in IRB:

```
irb(main):001:0> BRANCH_NAME = 'cocina-level2-updates'
=> "cocina-level2-updates"
irb(main):002:1* EXPECTED_PUSH_MESSAGES = [
irb(main):003:1*   "Branch '#{BRANCH_NAME}' set up to track remote branch '#{BRANCH_NAME}' from 'origin'",
irb(main):004:1*   "branch '#{BRANCH_NAME}' set up to track 'origin/#{BRANCH_NAME}'."
irb(main):005:0> ]
=> 
["Branch 'cocina-level2-updates' set up to track remote branch 'cocina-level2-updates' from 'origin'",
...
irb(main):006:0" result = "To github.com:sul-dlss/folio_client.git
irb(main):007:0"  * [new branch]      foo -> foo
irb(main):008:0> Branch 'foo' set up to track remote branch 'foo' from 'origin'."
=> "To github.com:sul-dlss/folio_client.git\n * [new branch]      foo -> foo\nBranch 'foo' set up to track remote branch...
irb(main):009:0> EXPECTED_PUSH_MESSAGES.find { |msg| result.include?(msg) } # result uses unexpected branch name, `#find` should return falsey value
=> nil

irb(main):010:0" result = "To github.com:sul-dlss/folio_client.git
irb(main):011:0"  * [new branch]      cocina-level2-updates -> cocina-level2-updates
irb(main):012:0> Branch 'cocina-level2-updates' set up to track remote branch 'cocina-level2-updates' from 'origin'."
=> "To github.com:sul-dlss/folio_client.git\n * [new branch]      cocina-level2-updates -> cocina-level2-updates\nBranch...
irb(main):013:0> EXPECTED_PUSH_MESSAGES.find { |msg| result.include?(msg) } # should return a truthy value

=> "Branch 'cocina-level2-updates' set up to track remote branch 'cocina-level2-updates' from 'origin'"
irb(main):014:0" result = "To github.com:sul-dlss/folio_client.git
irb(main):015:0"  * [new branch]      cocina-level2-updates -> cocina-level2-updates
irb(main):016:0> branch 'cocina-level2-updates' set up to track 'origin/cocina-level2-updates'."
=> "To github.com:sul-dlss/folio_client.git\n * [new branch]      cocina-level2-updates -> cocina-level2-updates\nbranch...
irb(main):017:0> EXPECTED_PUSH_MESSAGES.find { |msg| result.include?(msg) } # should return a truthy value
=> "branch 'cocina-level2-updates' set up to track 'origin/cocina-level2-updates'."
irb(main):018:0> 
```

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
