### PR TITLE
Fix output of GH links sent via Slack

### DIFF
--- a/git_hub_links.rb
+++ b/git_hub_links.rb
@@ -33,10 +33,10 @@ class GitHubLinks
     end.map(&:to_s).join("\n")
 
     [
-      '*Weekly dependency update time is here!*',
-      "\nBelow you will find the content for our weekly dependency update spreadsheet",
-      "```#{repo_content}```"
-    ].join(' ')
+      "*Weekly dependency update time is here!*\n",
+      "Below you will find the content for our weekly dependency update spreadsheet\n",
+      "```\n#{repo_content}\n```"
+    ].join
   end
 
   def repos


### PR DESCRIPTION
Something broke the rendering of the weekly dependency update Slack message between January 15th (when it rendered as expected) and January 22nd (when the backticks started failing to render as monospace/code). The unexpected rendering continued on January 29th. (Wrinkle: this unexpected rendering only affected the Infrastructure projects, not the Access ones. :shrug:)

![Screenshot from 2024-01-29 09-26-52](https://github.com/sul-dlss/access-update-scripts/assets/131982/2d31baf4-bafb-4e5b-a209-7a9430d83e04)

You can see the literal backticks coming through above instead of rendering the text as code.

None of [the commits that landed in `access-update-scripts` during this seven-day span](https://github.com/sul-dlss/access-update-scripts/commits/master/) look obviously related to this change in behavior---but if a reviewer sees an obvious bug, holler at me and I'll be happy to make a more direct fix.

The change made here: make sure there is a newline between the multi-line code text (triple backticks) and the list of projects.

To test this change, I created a temporary slack app and hand-jammed in a change to send the Slack message as a DM to my account, and I can confirm the output is now as expected for both the Access and Infrastructure projects:

![Screenshot from 2024-01-29 09-41-13](https://github.com/sul-dlss/access-update-scripts/assets/131982/007a6a44-9acd-427a-ab49-18e3ab8893d5)

![Screenshot from 2024-01-29 09-41-31](https://github.com/sul-dlss/access-update-scripts/assets/131982/c9e5b031-fdc3-48a8-ab9c-1c8da38d54f4)

