### PR TITLE
[HOLD] Break repo list into multiple messages

### DIFF
--- a/git_hub_links.rb
+++ b/git_hub_links.rb
@@ -20,7 +20,9 @@ class GitHubLinks
   end
 
   def render
-    SlackBot.new.message(text: slack_bot_content)
+    slack_bot_content.each do |text|
+      SlackBot.new.message(text: text)
+    end
   end
 
   private
@@ -30,13 +32,19 @@ class GitHubLinks
       pr, * = client.pull_requests(repo, head: "#{repo.split('/').first}:update-dependencies")
 
       "#{repo}\t#{pr && "#{pr[:html_url]}/files"}"
-    end.map(&:to_s).join("\n")
+    end.map(&:to_s)
 
-    [
-      "*Weekly dependency update time is here!*\n",
-      "Below you will find the content for our weekly dependency update spreadsheet\n",
-      "```\n#{repo_content}\n```"
-    ].join
+    messages_text(repo_content)
+  end
+
+  def messages_text(repo_content)
+    content_parts = [repo_content.slice(0..39), repo_content.slice(40..100)].compact
+    content_parts.map { |content| "```\n#{content.join("\n")}```" }
+
+    content_parts.prepend(
+      ["*Weekly dependency update time is here!*\n",
+       "Below you will find the content for our weekly dependency update spreadsheet\n"].join
+    )
   end
 
   def repos


### PR DESCRIPTION
If a Slack message is over approx. 4000 characters it can get truncated or split (with some characters getting lost). This PR splits the list of repos. Only the infra list at this point is long enough to get split. It does create an additional message for everyone since the intro text is now its own message. 

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/master/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / master ➡️ Build History ➡️ Cancel build button (🆇)
