### PR TITLE
Allow rialto-orgs to be auto-merged

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -57,7 +57,6 @@ projects:
     cocina_level2: false
   - repo: sul-dlss/rialto-orgs
     cocina_level2: false
-    merge: false
   - repo: sul-dlss/robot-console
     cocina_level2: false
   - repo: sul-dlss/sdr-api


### PR DESCRIPTION
Please be sure to kill the build as described below when merging. 

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/main/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / main ➡️ Build History ➡️ Cancel build button (🆇)
