### PR TITLE
add speech-to-text service to weekly dependency updates

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -65,6 +65,8 @@ projects:
     cocina_level2: false
   - repo: sul-dlss/sdr-deploy
     cocina_level2: false
+  - repo: sul-dlss/speech-to-text
+    cocina_level2: false
   - repo: sul-dlss/sul_pub
     cocina_level2: false
   - repo: sul-dlss/suri-rails


### PR DESCRIPTION
it's a python project, but the update hook was already added in https://github.com/sul-dlss/speech-to-text/pull/81

closes sul-dlss/speech-to-text#65 (i think?)

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/main/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / main ➡️ Build History ➡️ Cancel build button (🆇)
