### PR TITLE
Allow setting BRANCH_NAME via env

### DIFF
--- a/merge-all.rb
+++ b/merge-all.rb
@@ -8,7 +8,7 @@
 #   for infrastructure cocina-level2 PRs only
 #     note that COCINA_LEVEL2= is sufficient to be interpreted as true
 # "REPOS_PATH=infrastructure GH_ACCESS_TOKEN=abc123 COCINA_LEVEL2= ./merge-all.rb"
-BRANCH_NAME = 'update-dependencies'
+BRANCH_NAME = ENV.fetch('BRANCH_NAME', 'update-dependencies')
 COCINA_LEVEL2_BRANCH_NAME = 'cocina-level2-updates'
 
 require 'yaml'


### PR DESCRIPTION
This is a small change that I found very useful recently when working through a big batch of PRs for a specific change and all branches were named equally.

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/main/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / main ➡️ Build History ➡️ Cancel build button (🆇)
