### PR TITLE
Remove deprecated parse_date gem

### DIFF
--- a/infrastructure/projects.yml
+++ b/infrastructure/projects.yml
@@ -44,8 +44,6 @@ projects:
     cocina_level2: false
   - repo: sul-dlss/orcid_client
     cocina_level2: false
-  - repo: sul-dlss/parse_date
-    cocina_level2: false
   - repo: sul-dlss/pre-assembly
   - repo: sul-dlss/preservation-client
     cocina_level2: false


### PR DESCRIPTION
Simple change, will need to kill the build.

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/main/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / main ➡️ Build History ➡️ Cancel build button (🆇)
