### PR TITLE
Remove reference to dor_indexing

### DIFF
--- a/cocina_level2_prs.rb
+++ b/cocina_level2_prs.rb
@@ -75,7 +75,7 @@ end
 # must be called as part of the block for within_cloned_repo_dir(repo)
 def update_gems
   gemfile = File.read('Gemfile')
-  included_gems = %w[cocina-models dor-services-client sdr-client dor_indexing].filter { |gem_name| gemfile.include?(gem_name)}
+  included_gems = %w[cocina-models dor-services-client sdr-client].filter { |gem_name| gemfile.include?(gem_name)}
   ErrorEmittingExecutor.execute("bundle update #{included_gems.join(' ')}") unless included_gems.empty?
 end
 


### PR DESCRIPTION
Kill the build when merging:

⚠️ Pull request merger! ⚠️
If this is only a minor change to the scripts, please 🔪 [kill the Jenkins build.](https://sul-ci-prod.stanford.edu/job/SUL-DLSS/job/access-update-scripts/job/main/) 🔪

Navigate from SUL CI ➡️ Stanford University Digital Library ➡️ access-update-scripts ➡️ Branches / main ➡️ Build History ➡️ Cancel build button (🆇)
